### PR TITLE
Fix asset regex in vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
         // chunkFileNames: `assets/js/[name].js`,
         assetFileNames: (assetInfo) => {
           if (assetInfo.name) {
-            if (/\.( gif|jpeg|jpg|png|svg|webp| )$/.test(assetInfo.name)) {
+            if (/\.(gif|jpe?g|png|svg|webp)$/.test(assetInfo.name)) {
               return 'assets/images/[name].[ext]';
             }
             if (/\.css$/.test(assetInfo.name)) {


### PR DESCRIPTION
## Summary
- correct regex for images in `vite.config.ts`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684066c1ff248325b8e66be79be76a00