### PR TITLE
Increase checkbox hook test coverage

### DIFF
--- a/src/popup/useCheckboxState.test.tsx
+++ b/src/popup/useCheckboxState.test.tsx
@@ -35,4 +35,28 @@ describe('useCheckboxState', () => {
     expect(setMock).toHaveBeenCalledWith({ skipIntro: true });
     expect(result.current.isChecked).toBe(true);
   });
+
+  it('logs an error when chrome runtime reports one', () => {
+    const error = new Error('fail');
+    getMock.mockImplementation((_key: string, cb: (data: any) => void) => {
+      (global as any).chrome.runtime.lastError = error;
+      cb({});
+    });
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useCheckboxState('skipIntro'));
+
+    expect(result.current.isChecked).toBe(false);
+    expect(errorSpy).toHaveBeenCalledWith(error);
+
+    errorSpy.mockRestore();
+  });
+
+  it('defaults to false when storage has no value', () => {
+    getMock.mockImplementation((_key: string, cb: (data: any) => void) => cb({}));
+
+    const { result } = renderHook(() => useCheckboxState('skipIntro'));
+
+    expect(result.current.isChecked).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- add tests for chrome runtime error and undefined storage value
- reach 100% coverage for `useCheckboxState`

## Testing
- `npm test -- --coverage --findRelatedTests src/popup/useCheckboxState.ts`


------
https://chatgpt.com/codex/tasks/task_e_68406dff8d6c8325851feecd369d2248